### PR TITLE
Add popular spots API with database-backed implementation

### DIFF
--- a/src/main/java/live/b/api/spot/adapter/webapi/SpotApi.java
+++ b/src/main/java/live/b/api/spot/adapter/webapi/SpotApi.java
@@ -1,24 +1,25 @@
 package live.b.api.spot.adapter.webapi;
 
 import live.b.api.spot.application.SpotDto;
+import live.b.api.spot.application.provided.SpotFinder;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/spots")
+@RequiredArgsConstructor
 public class SpotApi {
 
+    private final SpotFinder spotFinder;
+
     @GetMapping("/popular")
-    public ResponseEntity<List<SpotDto>> popular() {
-        return ResponseEntity.ok(List.of(
-                new SpotDto(1L, "여행지1", "https://static.hubzum.zumst.com/hubzum/2024/03/25/14/a1aacd92e67e4b46802d082c47f07706.jpg"),
-                new SpotDto(2L, "여행지2", "https://static.hubzum.zumst.com/hubzum/2024/03/25/14/a1aacd92e67e4b46802d082c47f07706.jpg"),
-                new SpotDto(3L, "여행지3", "https://static.hubzum.zumst.com/hubzum/2024/03/25/14/a1aacd92e67e4b46802d082c47f07706.jpg"),
-                new SpotDto(4L, "여행지4", "https://static.hubzum.zumst.com/hubzum/2024/03/25/14/a1aacd92e67e4b46802d082c47f07706.jpg")
-        ));
+    public ResponseEntity<List<SpotDto>> popular(@RequestParam(required = false, defaultValue = "5") Integer limit) {
+        return ResponseEntity.ok(spotFinder.findPopular(limit));
     }
 }

--- a/src/main/java/live/b/api/spot/application/SpotQueryService.java
+++ b/src/main/java/live/b/api/spot/application/SpotQueryService.java
@@ -1,6 +1,7 @@
 package live.b.api.spot.application;
 
 import live.b.api.spot.application.provided.SpotFinder;
+import live.b.api.spot.application.required.SpotRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,8 +11,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SpotQueryService implements SpotFinder {
 
+    private final SpotRepository spotRepository;
+
     @Override
     public List<SpotDto> findPopular(int limit) {
-        return List.of();
+        return spotRepository.findAllOrderByPopularityDesc(limit);
     }
 }

--- a/src/main/java/live/b/api/spot/application/required/SpotRepositoryCustom.java
+++ b/src/main/java/live/b/api/spot/application/required/SpotRepositoryCustom.java
@@ -1,5 +1,17 @@
 package live.b.api.spot.application.required;
 
+import live.b.api.spot.application.SpotDto;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
 public interface SpotRepositoryCustom {
 
+    @Query("""
+            SELECT new live.b.api.spot.application.SpotDto(s.id, s.name, s.imageUrl)
+            FROM Spot s
+            ORDER BY s.popularity DESC
+            LIMIT :limit
+            """)
+    List<SpotDto> findAllOrderByPopularityDesc(int limit);
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,26 @@
+spring:
+  application:
+    name: b-live-api
+  mvc:
+    cors:
+      mappings:
+        [/**]:
+          allowed-origins: http://localhost:3000,https://api.ah.r-e.kr
+          allowed-methods: "GET,POST,PUT,DELETE,OPTIONS"
+          allowed-headers: "*"
+          allow-credentials: true
+          max-age: 3600
+  datasource:
+    hikari:
+      jdbc-url: jdbc:h2:mem:testdb
+      username: sa
+      password:
+      driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+  ai:
+    openai:
+      api-key: ${OPENAI_API_KEY}
+

--- a/src/test/java/live/b/api/BLiveApiApplicationTests.java
+++ b/src/test/java/live/b/api/BLiveApiApplicationTests.java
@@ -2,7 +2,9 @@ package live.b.api;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class BLiveApiApplicationTests {
 

--- a/src/test/java/live/b/api/spot/adapter/webapi/SpotApiTest.java
+++ b/src/test/java/live/b/api/spot/adapter/webapi/SpotApiTest.java
@@ -1,14 +1,21 @@
 package live.b.api.spot.adapter.webapi;
 
+import live.b.api.spot.application.SpotDto;
+import live.b.api.spot.application.provided.SpotFinder;
 import live.b.api.support.ApiDocumentationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
+
+import java.util.List;
 
 import static live.b.api.support.ApiDocumentUtils.getDocumentRequest;
 import static live.b.api.support.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -19,8 +26,18 @@ class SpotApiTest extends ApiDocumentationTest {
     @Autowired
     MockMvcTester mockMvcTester;
 
+    @MockitoBean
+    SpotFinder spotFinder;
+
     @Test
     void popular() {
+        when(spotFinder.findPopular(anyInt())).thenReturn(List.of(
+                new SpotDto(1L, "여행지1", "https://static.hubzum.zumst.com/hubzum/2024/03/25/14/a1aacd92e67e4b46802d082c47f07706.jpg"),
+                new SpotDto(2L, "여행지2", "https://static.hubzum.zumst.com/hubzum/2024/03/25/14/a1aacd92e67e4b46802d082c47f07706.jpg"),
+                new SpotDto(3L, "여행지3", "https://static.hubzum.zumst.com/hubzum/2024/03/25/14/a1aacd92e67e4b46802d082c47f07706.jpg"),
+                new SpotDto(4L, "여행지4", "https://static.hubzum.zumst.com/hubzum/2024/03/25/14/a1aacd92e67e4b46802d082c47f07706.jpg")
+        ));
+
         mockMvcTester.get().uri("/api/v1/spots/popular")
                 .contentType(MediaType.APPLICATION_JSON)
                 .assertThat()


### PR DESCRIPTION
- Introduced `/api/v1/spots/popular` endpoint to fetch popular spots.
- Implemented `SpotFinder`, `SpotRepositoryCustom`, and `SpotQueryService` for popularity-based spot queries.
- Added H2 test configuration with `application-test.yml`.
- Updated `SpotApiTest` with mocked service and dynamic response validation.